### PR TITLE
Number the screenshots

### DIFF
--- a/Tasks/GhostThemeUploader/ghostThemeUploaderTask.ts
+++ b/Tasks/GhostThemeUploader/ghostThemeUploaderTask.ts
@@ -18,9 +18,12 @@ const searchLocation = [
     path.join(process.env['programfiles(x86)'], '/google/chrome/Application/chrome.exe'),
 ]
 
+let screenshotCount = 0;
+
 async function takeScreenshot(page: puppeteer.Page, name: string) {
     if (takeScreenshotsEnabled) {
-        await page.screenshot({ path: path.join(screenshotPath, name) });
+        await page.screenshot({ path: path.join(screenshotPath, `${screenshotCount}_${name}`) });
+        screenshotCount++;
     }
 }
 


### PR DESCRIPTION
To help debugging the screenshots are invaluable. But without an order
to them it's very hard to figure out what happened in what order.